### PR TITLE
Fix set_ssh_keys.py

### DIFF
--- a/samples/set_ssh_key.py
+++ b/samples/set_ssh_key.py
@@ -1,6 +1,5 @@
 import cloudsigma
 import os
-import stat
 
 metadata = cloudsigma.metadata.GetServerMetadata().get()
 ssh_key = metadata['meta']['ssh_public_key']
@@ -12,13 +11,13 @@ authorized_keys = os.path.join(ssh_path, 'authorized_keys')
 
 
 def get_permission(path):
-    return oct(os.stat(ssh_path)[stat.ST_MODE])[-4:]
+    return oct(os.stat(path).st_mode)[-4:]
 
 if not os.path.isdir(ssh_path):
     print 'Creating folder %s' % ssh_path
     os.makedirs(ssh_path)
 
-if get_permission(ssh_path) != 0700:
+if get_permission(ssh_path) != '0700':
     print 'Setting permission for %s' % ssh_path
     os.chmod(ssh_path, 0700)
 
@@ -28,6 +27,6 @@ if get_permission(ssh_path) != 0700:
 with open(authorized_keys, 'a') as auth_file:
     auth_file.write(ssh_key + '\n')
 
-if get_permission(authorized_keys) != 0600:
+if get_permission(authorized_keys) != '0600':
     print 'Setting permission for %s' % authorized_keys
     os.chmod(authorized_keys, 0600)


### PR DESCRIPTION
Please review following changes:
- Fix `get_permission()` call to return permission string of given argument path. Also make use of `st_mode` attribute which removes need to import `stats` module to make code shorter and simpler.
- Fix permission checking `if` statement which always returns `False` as `get_permission()` call returns permission string and we're checking against octal permission value.
