### PR TITLE
Implement session-based login with OTP

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ simplejson>=3.17.0
 six>=1.14.0
 websocket-client>=0.57.0
 nose>=1.3.7
+pyotp


### PR DESCRIPTION
To be able to login with session based login with an OTP change your cloudsigma.conf to: 
```
api_endpoint = https://<YOUR API>.cloudsigma.com/api/2.0/
ws_endpoint = wss://direct.<YOUR API>.cloudsigma.com/websocket
username = <USERNAME>
password = <PASSWORD>
secret = <TOTP SECRET>
login_method = session
```
where teh TOTP Secret comes from the WebUI during the MFA enrollment process.